### PR TITLE
Update Makefile to fix compilation in Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ ${common.math.jar} :
 ## make sure jars from htslib exist
 ##
 $(filter-out ${htsjdk.home}/dist/htsjdk-${htsjdk.version}.jar  ,${htsjdk.jars}) : ${htsjdk.home}/dist/htsjdk-${htsjdk.version}.jar 
-	touch --no-create $@
+	touch -c $@
 
 ${htsjdk.home}/dist/htsjdk-${htsjdk.version}.jar : ${htsjdk.home}/build.xml
 	echo "Compiling htsjdk with $${JAVA_HOME} = ${JAVA_HOME}"


### PR DESCRIPTION
`touch` in Mac doesn't have the option `--no-create`, the equivalent option for Mac (that also exists in Linux) is `touch -c`