### PR TITLE
fixed memory leak in Biostar154220

### DIFF
--- a/src/main/java/com/github/lindenb/jvarkit/tools/biostar/Biostar154220.java
+++ b/src/main/java/com/github/lindenb/jvarkit/tools/biostar/Biostar154220.java
@@ -149,6 +149,8 @@ public class Biostar154220 extends AbstractBamWriterProgram
 							{
 							SAMSequenceRecord ssr=dict.getSequence(tid);
 							prev_tid=tid;
+							depth_array=null;
+							System.gc();
 							info("Alloc memory for contig "+ssr.getSequenceName()+" N="+ssr.getSequenceLength()+"*sizeof(int)");
 							depth_array=new int[ssr.getSequenceLength()+1];//use a +1 pos
 							Arrays.fill(depth_array, 0);


### PR DESCRIPTION
Hi Pierre, 

I plugged the memory leak like you suggested in #31 and it does the trick. It now never seems to need more than about 2Gb of memory. 

It would be nice to set `-Xmx4g` in the bash executable that is created as well, but I'm not familiar with how this would best be done, so for now I change that manually after compilation. 

Thanks! 