### PR TITLE
Add -a,--all option to cmpbams so it compares all reads

### DIFF
--- a/docs/CompareBams.md
+++ b/docs/CompareBams.md
@@ -10,6 +10,10 @@ Compare two or more BAM files
 ```
 Usage: cmpbams [options] Files
   Options:
+    -a, --all
+      compare all reads. Without this option reads marked as secondary or 
+      supplementary are discarded in the comparison
+      Default: false
     -c, --cigar
       use cigar String for comparaison
       Default: false

--- a/src/main/java/com/github/lindenb/jvarkit/tools/cmpbams/CompareBams.java
+++ b/src/main/java/com/github/lindenb/jvarkit/tools/cmpbams/CompareBams.java
@@ -281,6 +281,9 @@ public class CompareBams  extends Launcher
 	{
 	private static final Logger LOG = Logger.build(CompareBams.class).make();
 
+	@Parameter(names={"-a","--all"}, description="compare all reads. Without this option reads marked as secondary or supplementary are discarded in the comparison")
+	private boolean compareAllReads = false;
+
 	@Parameter(names={"-o","--output"},description=OPT_OUPUT_FILE_OR_STDOUT)
 	private Path outputFile = null;
 	
@@ -601,7 +604,7 @@ public class CompareBams  extends Launcher
 					if(!rec.getReadUnmappedFlag())
 						{
 						if(rec.getMappingQuality() < this.min_mapq) continue;
-						if(rec.isSecondaryOrSupplementary()) continue;
+						if(rec.isSecondaryOrSupplementary() && !compareAllReads) continue;
 						}
 					final Match m=new Match();
 					if(rec.getReadPairedFlag())


### PR DESCRIPTION
### Description
This commit adds the -a,--all option to cmpbams. When this option is
set, cmpbams will also compare reads marked as supplementary or
secondary.

This fixes #151.

### Checklist
- [x] Code compiles correctly
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added myself + history to the source file

