### PR TITLE
Biostar165777: close output streams in finally

### DIFF
--- a/src/main/java/com/github/lindenb/jvarkit/tools/biostar/Biostar165777.java
+++ b/src/main/java/com/github/lindenb/jvarkit/tools/biostar/Biostar165777.java
@@ -132,8 +132,8 @@ public class Biostar165777 extends Launcher
 			return -1;
 			}
 		XMLEventReader r = null;
+		final List<FileOutputStream> fwriters = new ArrayList<>();
 		try {
-			final List<FileOutputStream> fwriters = new ArrayList<>();
 			final List<XMLEventWriter> writers = new ArrayList<>();
 			final XMLOutputFactory xof=XMLOutputFactory.newFactory();
 			for(int i=0;i< this.count;++i)
@@ -208,16 +208,17 @@ public class Biostar165777 extends Launcher
 				w.flush();
 				CloserUtil.close(w);
 				}
-			for(final FileOutputStream w:fwriters)
-				{	
-				CloserUtil.close(w);
-				}
 			return RETURN_OK;
 			}
 		catch(final Exception err)
 			{
 			LOG.error(err);
 			return -1;
+			}
+			finally {
+				for(final FileOutputStream w:fwriters) {	
+					CloserUtil.close(w);
+				}
 			}
 		}
 	


### PR DESCRIPTION
### Problem
`Biostar165777#doWork()` creates multiple `FileOutputStreams` for output shards. On exceptions during XML reading/writing (or other early exits), these streams may not be closed, leaking file descriptors and potentially leaving output files locked.

### Fix
Move cleanup of the created `FileOutputStreams` into a finally block so they are closed on both success and failure paths.